### PR TITLE
[repeater-field_type] datepicker not showing up

### DIFF
--- a/resources/js/input.js
+++ b/resources/js/input.js
@@ -3,6 +3,7 @@ $(function () {
     // Initialize date pickers
     $('input[data-provides="anomaly.field_type.datetime"][name$="[date]"]').each(function () {
 
+        $('#ui-datepicker-div').remove();
         var input = $(this);
 
         input.prev('.icon').click(function () {


### PR DESCRIPTION
I've tried this solution from stackoverflow:
http://stackoverflow.com/a/29667897/7466444

The datepicker inside the repeater works great now :).
I've edited the /core/anomaly/datetime-field_type/resources/js/input.js file as follows:

```
$('input[data-provides="anomaly.field_type.datetime"][name$="[date]"]:not([data-initialized])').each(function () {

        //Remove div from DOM
        $('#ui-datepicker-div').remove();
        var input = $(this);
        ...
```
For some reason jQuery doesn't initialize DatePicker if this div is present in DOM.