### PR TITLE
bug fix datetime FT validation

### DIFF
--- a/src/Validation/ValidateDatetime.php
+++ b/src/Validation/ValidateDatetime.php
@@ -1,6 +1,6 @@
 <?php namespace Anomaly\DatetimeFieldType\Validation;
 
-use Anomaly\DatetimeFieldType\DatetimeFieldType;
+use Anomaly\Streams\Platform\Ui\Form\FormBuilder;
 use Carbon\Carbon;
 
 /**
@@ -16,12 +16,14 @@ class ValidateDatetime
     /**
      * Handle the validation.
      *
-     * @param DatetimeFieldType $fieldType
-     * @param                   $value
+     * @param FormBuilder   $builder
+     * @param               $attribute
+     * @param               $value
      * @return bool
      */
-    public function handle(DatetimeFieldType $fieldType, $value)
+    public function handle(FormBuilder $builder, $attribute, $value)
     {
+        $fieldType = $builder->getFormFieldFromAttribute($attribute);
         try {
             (new Carbon())->createFromFormat($fieldType->getDatetimeFormat(), $value);
         } catch (\Exception $e) {


### PR DESCRIPTION
Validation fails when I have more than one datetime FT with different formats.
One way to reproduce the issue:
Go to posts module -> assign one datetime field -> assign one time field -> populate the form -> submit.

Populate FT:
![before_save](https://cloud.githubusercontent.com/assets/25120167/22620547/43c76e52-eb06-11e6-8a64-c103dfb90d03.png)

After Submit:
![after_save](https://cloud.githubusercontent.com/assets/25120167/22620559/5836bef6-eb06-11e6-9bd4-e69cd86d56ca.png)