### PR TITLE
add support for 24hours format of timepicker

### DIFF
--- a/resources/js/picker.js
+++ b/resources/js/picker.js
@@ -11,6 +11,7 @@ $(document).on('ajaxComplete ready', function () {
             allowInput: true,
             minuteIncrement: $this.data('step') || 1,
             dateFormat: $this.data('datetime-format'),
+            time_24hr: $this.attr('data-datetime-format-24hr') ? true : false,
             enableTime: inputMode !== 'date',
             noCalendar: inputMode === 'time'
         };

--- a/resources/views/picker.twig
+++ b/resources/views/picker.twig
@@ -14,7 +14,7 @@
             value="{{ field_type.format(field_type.datetime_format) }}"
             placeholder="{{ 'now'|date(field_type.datetime_format) }}"
             data-datetime-format="{{ field_type.plugin_format }}"
-            data-datetime-format-24hr="{{ field_type.plugin_format == 'Y-m-d H:i' or field_type.plugin_format == 'H:i'}}"
+            data-datetime-format-24hr="{{ 'H:i' in field_type.plugin_format }}"
             {{ html_attributes(field_type.attributes) }}
             {{ field_type.required ? 'required' }}
             {{ field_type.disabled ? 'disabled' }}

--- a/resources/views/picker.twig
+++ b/resources/views/picker.twig
@@ -14,6 +14,7 @@
             value="{{ field_type.format(field_type.datetime_format) }}"
             placeholder="{{ 'now'|date(field_type.datetime_format) }}"
             data-datetime-format="{{ field_type.plugin_format }}"
+            data-datetime-format-24hr="{{ field_type.plugin_format == 'Y-m-d H:i' or field_type.plugin_format == 'H:i'}}"
             {{ html_attributes(field_type.attributes) }}
             {{ field_type.required ? 'required' }}
             {{ field_type.disabled ? 'disabled' }}


### PR DESCRIPTION
added support for 24hours.

when we switched to time format H:i
it would not work, it would show AM/PM anyway in the picker

this solves it.
Example: http://pic.webas.lt/webas.lt-3836cc9c7b.png
