### PR TITLE
Removed forcing users behavior

### DIFF
--- a/src/DatetimeFieldType.php
+++ b/src/DatetimeFieldType.php
@@ -132,11 +132,6 @@ class DatetimeFieldType extends FieldType
             $config['time_format'] = $this->configuration->get('streams::datetime.time_format');
         }
 
-        // Make sure format is supported.
-        if (!in_array($config['date_format'], array_keys($formats))) {
-            $config['date_format'] = array_first(array_keys($formats));
-        }
-
         return $config;
     }
 


### PR DESCRIPTION
These lines had forced user to use the date format from the list only.
I don't know why do you need them, but I need to have custom date formats.

For example for inject cases relative finishing of a word (In Russian, Italian and more).