### PR TITLE
Update DatetimeFieldTypePresenter.php

### DIFF
--- a/src/DatetimeFieldTypePresenter.php
+++ b/src/DatetimeFieldTypePresenter.php
@@ -36,7 +36,7 @@ class DatetimeFieldTypePresenter extends FieldTypePresenter
         }
 
         if ($value instanceof Carbon) {
-            return $value->format($format);
+            return $value->year > 0 ? $value->format($format) : null;
         }
 
         try {


### PR DESCRIPTION
Check that its a valid > 0 year to ensure that Carbon has been instantiated on a non 0000 datetime. Not sure if this is the best type of check for it, or if it should go on the raw attribute getter, but I was having a brain fart and couldn't remember where that was. Default value of null on datetime for migration seems to do nothing, that would also fix tihs problem.