### PR TITLE
Update array key

### DIFF
--- a/docs/en/01.introduction/02.configuration.md
+++ b/docs/en/01.introduction/02.configuration.md
@@ -9,7 +9,7 @@ Below is the full configuration available with defaults values:
     "example" => [
         "type"   => "anomaly.field_type.datetime",
         "config" => [
-            "default_value" => null,
+            "default"       => null,
             "mode"          => "datetime",
             "date_format"   => "j F, Y",
             "year_range"    => "-50:+50",


### PR DESCRIPTION
Tested using both, `default_value` would throw an error.