### PR TITLE
resources/js/l10n/en.js] does not exist!

### DIFF
--- a/resources/views/picker.twig
+++ b/resources/views/picker.twig
@@ -3,11 +3,13 @@
 {{ asset_add("styles.css", "anomaly.field_type.datetime::scss/light.scss") }}
 {{ asset_add("styles.css", "anomaly.field_type.datetime::scss/picker.scss") }}
 
-{% for locale in config('streams::locales.enabled') %}
+{% for locale in config('streams::locales.enabled') if locale != 'en' %}
     {{ asset_add("scripts.js", "anomaly.field_type.datetime::js/l10n/" ~ locale ~ ".js", ["ignore"]) }}
 {% endfor %}
 
-{{ asset_add("scripts.js", "anomaly.field_type.datetime::js/l10n/" ~ config('app.locale') ~ ".js", ["ignore"]) }}
+{% if config('app.locale') != 'en' %}
+    {{ asset_add("scripts.js", "anomaly.field_type.datetime::js/l10n/" ~ config('app.locale') ~ ".js", ["ignore"]) }}
+{% endif %}
 
 {{ asset_add("scripts.js", "anomaly.field_type.datetime::js/picker.js") }}
 


### PR DESCRIPTION
Hello,

when switching to ENglish language, we constantly are getting this. there is no 'en' file in the repo, since EN is the default/builtin.

Original error
```bash
An exception has been thrown during the rendering of a template ("Asset [/home/x/Projects/app-x/core/anomaly/datetime-field_type/resources/js/l10n/en.js] does not exist!") in "/home/x/Projects/app-x/core/anomaly/datetime-field_type/resources/views/picker.twig" at line 7.
```

and other question is - do we need all locales enabled? maybe only incllude the one, active? or they are built into one file later for faster speed?