### PR TITLE
Allow datetimes in locales other than the default to be nullable

### DIFF
--- a/src/DatetimeFieldType.php
+++ b/src/DatetimeFieldType.php
@@ -112,6 +112,11 @@ class DatetimeFieldType extends FieldType
     public function getRules()
     {
         $rules = parent::getRules();
+        
+        // If the locale is not the default locale, allow the value to be null
+        if ($this->locale != config('streams::locales.default')) {
+            $rules[] = 'nullable';
+        }
 
         // We expect an array.
         $rules[] = 'array';


### PR DESCRIPTION
This fixes errors from appearing like:

![](http://yo.bkwld.com/d78ed08d9215/Image%202019-02-14%20at%2012.26.43%20PM.png)