### PR TITLE
php8.0 fix

### DIFF
--- a/src/DatetimeFieldTypePresenter.php
+++ b/src/DatetimeFieldTypePresenter.php
@@ -143,9 +143,9 @@ class DatetimeFieldTypePresenter extends FieldTypePresenter
      * @return mixed
      */
     public function __call($method, $arguments)
-    {
+    {    
         // Check if carbon has the method.
-        if (method_exists($value = $this->object->getValue(), $method)) {
+        if (is_string($value = $this->object->getValue()) && method_exists($value = $tmp, $method)) {
             return call_user_func_array([$value, $method], $arguments);
         }
 

--- a/src/DatetimeFieldTypePresenter.php
+++ b/src/DatetimeFieldTypePresenter.php
@@ -145,7 +145,7 @@ class DatetimeFieldTypePresenter extends FieldTypePresenter
     public function __call($method, $arguments)
     {    
         // Check if carbon has the method.
-        if (is_string($value = $this->object->getValue()) && method_exists($value = $tmp, $method)) {
+        if (is_string($value = $this->object->getValue()) && method_exists($value, $method)) {
             return call_user_func_array([$value, $method], $arguments);
         }
 


### PR DESCRIPTION
method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given