### PR TITLE
Set date only formats to start of day

### DIFF
--- a/src/DatetimeFieldTypeModifier.php
+++ b/src/DatetimeFieldTypeModifier.php
@@ -95,6 +95,10 @@ class DatetimeFieldTypeModifier extends FieldTypeModifier
         if ($this->fieldType->config('mode') !== 'date') {
             $value->setTimezone(array_get($this->fieldType->getConfig(), 'timezone'));
         }
+        
+        if ($this->fieldType->config('mode') == 'date') {
+            $value->startOfDay();
+        }
 
         if ($this->fieldType->getEntry() instanceof VariablesTestingEntryModel) {
             //dd($value->setTimezone($this->config->get('streams::datetime.database_timezone')));


### PR DESCRIPTION
Set the date only formats to be the start of the day, otherwise there is a time always appended for whatever the current query time is which just causes issues.